### PR TITLE
[AB#26794] Too long option titles breaks the Slide frame.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyvoting/electa-ui",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/components/molecules/AVResultOption/AVResultOption.vue
+++ b/src/components/molecules/AVResultOption/AVResultOption.vue
@@ -103,7 +103,7 @@ watch(
           }}
         </span>
       </div>
-      <div class="vstack align-items-end gap-1" data-test="result-results">
+      <div class="vstack align-items-end justify-content-center gap-1" data-test="result-results">
         <p class="mb-0">{{ truncatedVotes }}</p>
         <p v-if="!hidePercentage" class="text-dark mb-0">{{ optionPercent }}%</p>
       </div>

--- a/src/components/organisms/AVNormalSummary/AVNormalSummary.scss
+++ b/src/components/organisms/AVNormalSummary/AVNormalSummary.scss
@@ -3,7 +3,7 @@
 }
 
 .AVNormalSummary {
-  grid-template-columns: 1fr;
+  grid-template-columns: 100%;
   grid-auto-rows: auto;
 }
 


### PR DESCRIPTION
[AB#26794](https://dev.azure.com/lumiholdings/219d6ec9-9d0d-4762-a957-7317c3dbfbb6/_workitems/edit/26794)


https://github.com/user-attachments/assets/df4089a7-f133-4637-80af-1ac44cf46442

