### PR TITLE
[AB#28783] Order options on summary accodting to voting type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyvoting/electa-ui",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/components/organisms/AVPileSummary/AVPileSummary.vue
+++ b/src/components/organisms/AVPileSummary/AVPileSummary.vue
@@ -135,6 +135,16 @@ const getWriteInOption = (reference: string) => {
   )?.text;
 };
 
+const orderedSummaryOptions = computed(() => {
+  if (props.contest.markingType.voteVariation === "ranked") return optionSummaries.value;
+
+  return [...optionSummaries.value].sort((a, b) => {
+    const indexA = selectableOptions.value.findIndex((o) => o.reference === a.reference);
+    const indexB = selectableOptions.value.findIndex((o) => o.reference === b.reference);
+    return indexA - indexB;
+  });
+});
+
 /**
  * This is necesary in order to support both provided i18n and local i18n.
  * The used locale will be taken from the provided i18n as long as there is one
@@ -201,7 +211,7 @@ watch(
       }"
     >
       <AVSummaryOption
-        v-for="(option, index) in optionSummaries"
+        v-for="(option, index) in orderedSummaryOptions"
         :key="index"
         :option="option"
         :multiple-votes-allowed="


### PR DESCRIPTION
<img width="1329" height="1318" alt="Screenshot 2026-04-21 at 16 04 41" src="https://github.com/user-attachments/assets/27acf2a3-fc25-49ce-804a-f4019b778b6e" />

<img width="1329" height="1318" alt="Screenshot 2026-04-21 at 16 04 49" src="https://github.com/user-attachments/assets/e30be0f3-c152-4bd0-8964-9c5d03652d2a" />
