### PR TITLE
Restructure error modal layout with proper header, body, and footer sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyvoting/electa-ui",
-  "version": "5.6.2-beta.4",
+  "version": "5.6.2-beta.5",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.scss
+++ b/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.scss
@@ -1,5 +1,9 @@
 @import "../../../../node_modules/bootstrap/scss/bootstrap-utilities";
 
+.my-modal-backdrop {
+  background-color: rgba($black, 0.5);
+}
+
 .AVSubmissionHelper--quadratic {
   float: none;
   display: flex;

--- a/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.scss
+++ b/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.scss
@@ -4,6 +4,16 @@
   background-color: rgba($black, 0.5);
 }
 
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.15s linear;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
 .AVSubmissionHelper--quadratic {
   float: none;
   display: flex;

--- a/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
+++ b/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
@@ -233,7 +233,7 @@ watch(
         submission helper adds a z-index of 1020 and this needs to be on top -->
         <div
           class="d-block modal my-modal-backdrop show fade"
-          style="z-index: 1050 !important"
+          style="z-index: 1055 !important"
           tabindex="-1"
           role="alertdialog"
           aria-modal="true"

--- a/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
+++ b/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
@@ -227,10 +227,10 @@ watch(
     </div>
 
     <!-- ERROR MODAL -->
-    <transition name="modal" tag="div">
+    <transition name="modal">
       <template v-if="displayErrorModal && showErrorModal && errors.length > 0">
-        <!-- z-index added because "sticky-bottom" bootstrap class used in
-        submission helper adds an z-index of 1020 and this needs to be on top -->
+        <!-- z-index added because "sticky-bottom" Bootstrap class used in
+        submission helper adds a z-index of 1020 and this needs to be on top -->
         <div
           class="d-block modal my-modal-backdrop show fade"
           style="z-index: 1050 !important"
@@ -256,7 +256,7 @@ watch(
               </header>
 
               <!-- BODY -->
-              <main class="modal-body">
+              <div class="modal-body">
                 <div id="error-modal-message">
                   <p
                     v-for="(errorMessage, index) in errorMessages"
@@ -267,7 +267,7 @@ watch(
                     {{ errorMessage }}
                   </p>
                 </div>
-              </main>
+              </div>
 
               <!-- FOOTER -->
               <footer class="modal-footer justify-content-end">

--- a/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
+++ b/src/components/molecules/AVSubmissionHelper/AVSubmissionHelper.vue
@@ -227,46 +227,65 @@ watch(
     </div>
 
     <!-- ERROR MODAL -->
-    <template v-if="displayErrorModal && showErrorModal && errors.length > 0">
-      <div class="modal-backdrop fade show"></div>
-      <div
-        class="modal fade show d-block"
-        tabindex="-1"
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="error-modal-title"
-        aria-describedby="error-modal-message"
-        data-test="error-modal"
-        @keydown.esc="dismissErrorModal"
-      >
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <div class="modal-body text-center p-4">
-              <div class="mb-3">
-                <AVIcon icon="triangle-exclamation" class="text-warning fs-1" />
-              </div>
-              <h2 id="error-modal-title" class="visually-hidden">
-                {{ t("js.components.AVSubmissionHelper.error_modal_title") }}
-              </h2>
-              <div id="error-modal-message" class="mb-4">
-                <p v-for="(errorMessage, index) in errorMessages" :key="index" role="alert">
-                  {{ errorMessage }}
-                </p>
-              </div>
-              <button
-                ref="dismissButtonRef"
-                type="button"
-                class="btn btn-primary"
-                @click="dismissErrorModal"
-                data-test="dismiss-error-modal"
-              >
-                {{ t("js.components.AVSubmissionHelper.error_modal_dismiss") }}
-              </button>
+    <transition name="modal" tag="div">
+      <template v-if="displayErrorModal && showErrorModal && errors.length > 0">
+        <!-- z-index added because "sticky-bottom" bootstrap class used in
+        submission helper adds an z-index of 1020 and this needs to be on top -->
+        <div
+          class="d-block modal my-modal-backdrop show fade"
+          style="z-index: 1050 !important"
+          tabindex="-1"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="error-modal-title"
+          aria-describedby="error-modal-message"
+          data-test="error-modal"
+          @keydown.esc="dismissErrorModal"
+          @click.self="dismissErrorModal"
+        >
+          <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+              <!-- HEADER -->
+              <header class="modal-header d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center gap-2">
+                  <AVIcon icon="triangle-exclamation" class="text-warning fs-5" />
+                  <h5 id="error-modal-title" class="modal-title mb-0">
+                    {{ t("js.components.AVSubmissionHelper.error_modal_title") }}
+                  </h5>
+                </div>
+              </header>
+
+              <!-- BODY -->
+              <main class="modal-body">
+                <div id="error-modal-message">
+                  <p
+                    v-for="(errorMessage, index) in errorMessages"
+                    :key="index"
+                    role="alert"
+                    class="mb-2"
+                  >
+                    {{ errorMessage }}
+                  </p>
+                </div>
+              </main>
+
+              <!-- FOOTER -->
+              <footer class="modal-footer justify-content-end">
+                <button
+                  ref="dismissButtonRef"
+                  type="button"
+                  class="btn btn-primary"
+                  @click="dismissErrorModal"
+                  data-test="dismiss-error-modal"
+                >
+                  {{ t("js.components.AVSubmissionHelper.error_modal_dismiss") }}
+                </button>
+              </footer>
             </div>
           </div>
         </div>
-      </div>
-    </template>
+      </template>
+    </transition>
   </div>
 </template>
 


### PR DESCRIPTION
Replace centered single-body modal layout with standard Bootstrap modal structure including separate header with icon and title, scrollable body for error messages, and footer with dismiss button. Add transition wrapper, click-outside-to-close functionality, and custom backdrop styling with z-index 1050 to ensure modal appears above sticky-bottom elements. Update modal-title to use h5 element instead of visually-hidden h