### PR TITLE
Prevent blocked-click emission when deselecting options at max selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyvoting/electa-ui",
-  "version": "5.7.2-ontario",
+  "version": "5.7.3-ontario",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/components/molecules/AVOption/AVOption.spec.ts
+++ b/src/components/molecules/AVOption/AVOption.spec.ts
@@ -802,5 +802,26 @@ describe("AVOption", () => {
       await blockedWrapper.find("[data-test=option-checkbox]").trigger("click");
       expect(blockedWrapper.emitted("blocked-click")).toBeUndefined();
     });
+
+    it("emits blocked-click when increasing votes in multi-vote mode and maxSelectionsReached", async () => {
+      const blockedWrapper = mountAVOption({
+        contest: getContest(["multiple_votes_sm"]),
+        maxSelectionsReached: true,
+        selections: [{ reference: "exampleOption1" }],
+      });
+      await blockedWrapper.findAll("[data-test=option-checkbox]")[1].trigger("click");
+      expect(blockedWrapper.emitted("blocked-click")).toBeDefined();
+      expect(blockedWrapper.emitted("checked")).toBeUndefined();
+    });
+
+    it("does not emit blocked-click when decreasing votes in multi-vote mode and maxSelectionsReached", async () => {
+      const blockedWrapper = mountAVOption({
+        contest: getContest(["multiple_votes_sm"]),
+        maxSelectionsReached: true,
+        selections: [{ reference: "exampleOption1" }, { reference: "exampleOption1" }],
+      });
+      await blockedWrapper.findAll("[data-test=option-checkbox]")[1].trigger("click");
+      expect(blockedWrapper.emitted("blocked-click")).toBeUndefined();
+    });
   });
 });

--- a/src/components/molecules/AVOption/AVOption.spec.ts
+++ b/src/components/molecules/AVOption/AVOption.spec.ts
@@ -782,5 +782,25 @@ describe("AVOption", () => {
       await parentWrapper.find("[data-test=option-section]").trigger("click");
       expect(parentWrapper.emitted("blocked-click")).toBeDefined();
     });
+
+    it("emits blocked-click when checkbox is clicked directly and maxSelectionsReached", async () => {
+      const blockedWrapper = mountAVOption({
+        maxSelectionsReached: true,
+        selections: [],
+      });
+      await blockedWrapper.find("[data-test=option-checkbox]").trigger("click");
+      expect(blockedWrapper.emitted("blocked-click")).toBeDefined();
+      expect(blockedWrapper.emitted("blocked-click")).toHaveLength(1);
+      expect(blockedWrapper.emitted("checked")).toBeUndefined();
+    });
+
+    it("does not emit blocked-click when checkbox is clicked and option is already selected", async () => {
+      const blockedWrapper = mountAVOption({
+        maxSelectionsReached: true,
+        selections: [{ reference: "exampleOption1" }],
+      });
+      await blockedWrapper.find("[data-test=option-checkbox]").trigger("click");
+      expect(blockedWrapper.emitted("blocked-click")).toBeUndefined();
+    });
   });
 });

--- a/src/components/molecules/AVOption/AVOption.vue
+++ b/src/components/molecules/AVOption/AVOption.vue
@@ -386,6 +386,14 @@ const isBlocked = computed(
     props.selectionMode !== "radio",
 );
 
+const handleCheckboxToggle = (reference: string, amount: number, text?: string): void => {
+  if (props.maxSelectionsReached && checkedCount.value === 0 && props.selectionMode !== "radio") {
+    emits("blocked-click");
+    return;
+  }
+  toggleOption(reference, amount, text);
+};
+
 const toggleFromWriteIn = (e: Event): void => {
   e.preventDefault();
   e.stopPropagation();
@@ -576,7 +584,7 @@ watch(
                   :disabled="disabled || observerMode"
                   :gallery-mode="contest.mode === 'gallery'"
                   :selection-style="selectionStyle"
-                  @toggled="toggleOption(option.reference, optionGroups[0][0], writeInText)"
+                  @toggled="handleCheckboxToggle(option.reference, optionGroups[0][0], writeInText)"
                 />
               </div>
             </div>
@@ -762,7 +770,7 @@ watch(
                   :disabled="disabled || observerMode"
                   :gallery-mode="false"
                   :selection-style="selectionStyle"
-                  @toggled="toggleOption(option.reference, optionIndex, writeInText)"
+                  @toggled="handleCheckboxToggle(option.reference, optionIndex, writeInText)"
                 />
               </div>
             </div>

--- a/src/components/molecules/AVOption/AVOption.vue
+++ b/src/components/molecules/AVOption/AVOption.vue
@@ -387,7 +387,11 @@ const isBlocked = computed(
 );
 
 const handleCheckboxToggle = (reference: string, amount: number, text?: string): void => {
-  if (props.maxSelectionsReached && checkedCount.value === 0 && props.selectionMode !== "radio") {
+  if (
+    props.maxSelectionsReached &&
+    amount > checkedCount.value &&
+    props.selectionMode !== "radio"
+  ) {
     emits("blocked-click");
     return;
   }


### PR DESCRIPTION
- Add handleCheckboxToggle function to check if option is being selected (checkedCount === 0) before emitting blocked-click
- Emit blocked-click only when attempting to select a new option at max selections, not when deselecting
- Replace direct toggleOption calls with handleCheckboxToggle for checkbox interactions
