### PR TITLE
AB#29656 Prevent option selection when clicking links or videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assemblyvoting/electa-ui",
-  "version": "5.7.3-ontario",
+  "version": "5.8.1-ontario.beta1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/components/molecules/AVOption/AVOption.vue
+++ b/src/components/molecules/AVOption/AVOption.vue
@@ -371,7 +371,7 @@ const handleOptionClick = (event: MouseEvent): void => {
   if (props.disabled || props.observerMode || !props.option.selectable || counterInterface.value)
     return;
 
-  if (event.target && (event.target as Element).closest("a, video")) {
+  if (event.target instanceof Element && event.target.closest("a, video")) {
     return;
   }
 

--- a/src/components/molecules/AVOption/AVOption.vue
+++ b/src/components/molecules/AVOption/AVOption.vue
@@ -367,9 +367,13 @@ Result:
 ✅ Radio mode → Always allowed (radio handles its own logic)
 */
 
-const handleOptionClick = (): void => {
+const handleOptionClick = (event: MouseEvent): void => {
   if (props.disabled || props.observerMode || !props.option.selectable || counterInterface.value)
     return;
+
+  if (event.target && (event.target as Element).closest("a, video")) {
+    return;
+  }
 
   if (props.maxSelectionsReached && checkedCount.value === 0 && props.selectionMode !== "radio") {
     emits("blocked-click");


### PR DESCRIPTION
[AB#29656](https://dev.azure.com/lumiholdings/219d6ec9-9d0d-4762-a957-7317c3dbfbb6/_workitems/edit/29656)

## Summary

Fixes #29656 — clicking a hyperlink or video inside a candidate's description text would inadvertently select the candidate option. The click handler now ignores events that originate from within anchor or video elements.

## Changes

- **AVOption**: `handleOptionClick` now accepts the `MouseEvent` and returns early when the click target is inside an `<a>` or `<video>` element, preventing unintended option selection.
- **Version**: Bumped package version from `5.7.3-ontario` to `5.8.1-ontario.beta1`.